### PR TITLE
feat: status bar on course page wrt the progress

### DIFF
--- a/lms/www/courses/course.html
+++ b/lms/www/courses/course.html
@@ -222,9 +222,16 @@
         </a>
 
         {% elif membership %}
+        {% set progress = frappe.utils.cint(membership.progress) %}
         <a class="btn btn-primary wide-button" id="continue-learning"
             href="{{ get_lesson_url(course.name, lesson_index) }}{{ course.query_parameter }}">
-            {{ _("Continue Learning") }}
+            {% if progress == 0 %}
+              {{ _("Start Learning") }}
+            {% elif progress == 100 %}
+              {{ _("Course Completed") }}
+            {% else %}
+              {{ progress }}% {{ _("Completed, ") }}{{ _("Continue Learning") }}
+            {% endif %}
         </a>
 
         {% elif course.paid_course and not is_instructor %}
@@ -237,8 +244,6 @@
             {{ _("Start Learning") }}
         </div>
         {% endif %}
-
-        {% set progress = frappe.utils.cint(membership.progress) %}
 
         {% if membership and course.enable_certification %}
             {% if certificate %}


### PR DESCRIPTION
- Add status bar on course page with respect to the progress

Before the PR
![Screenshot 2024-01-22 at 1 45 47 PM](https://github.com/ONE-F-M/lms/assets/20554466/008f59f5-8fe7-4850-a3f4-59a4656a9b4a)

After the PR
![Screenshot 2024-01-22 at 1 46 32 PM](https://github.com/ONE-F-M/lms/assets/20554466/70ef19f7-2ec2-454b-b5f5-1f8cbf54cfac)
![Screenshot 2024-01-22 at 1 51 27 PM](https://github.com/ONE-F-M/lms/assets/20554466/ef1222af-f816-4d61-9793-b163c008a904)

