### PR TITLE
Feat: Change the lesson body from markdown to text editor

### DIFF
--- a/lms/lms/doctype/course_lesson/course_lesson.json
+++ b/lms/lms/doctype/course_lesson/course_lesson.json
@@ -67,7 +67,7 @@
   },
   {
    "fieldname": "body",
-   "fieldtype": "Markdown Editor",
+   "fieldtype": "Text Editor",
    "ignore_xss_filter": 1,
    "label": "Body",
    "reqd": 1
@@ -135,7 +135,7 @@
   },
   {
    "fieldname": "instructor_notes",
-   "fieldtype": "Markdown Editor",
+   "fieldtype": "Text Editor",
    "label": "Instructor Notes"
   }
  ],


### PR DESCRIPTION
## Is this a Feature, Chore or Bug?
- [x] Feature
- [ ] Chore
- [ ] Bug


## Clearly and concisely describe the feature, chore or bug.
-Change the lesson body from markdown to text editor

## Solution description
The Editor Body and Instruction were changed from Markdown to Text.

## Is there a business logic within a doctype?
    - [ ] Yes
    - [x] No


## Output screenshots (optional)

https://github.com/ONE-F-M/lms/assets/29017559/9fdeb9f5-4b39-4e6a-aebe-d234758798c1



## Areas affected and ensured
The Editor for Body and Instruction was changed from Markdown to Text.

## Is there any existing behaviour change of other features due to this code change?
No.

## Did you test with the following dataset?
- [x] Existing Data
- [x] New Data

## Was child table created?
    - [ ] is attachment required?
        did you test attachment
## Did you delete custom field?
    - [ ] Yes
    - [x] No
        If yes, did you write a delete patch?

## Is patch required?
- [ ] Yes
- [x] No
    ## Was the patch test?


## Which browser(s) did you use for testing?
  - [x] Chrome
  - [x] Safari
  - [x] Firefox