### PR TITLE
feat: Standardize email templates

### DIFF
--- a/lms/lms/notification/notifications.py
+++ b/lms/lms/notification/notifications.py
@@ -14,7 +14,7 @@ def notify_course_completion():
     # Get all completed course(LMS Enrollment) that not send the notification to instructor
     query = '''
         select
-            course, member_name, name
+            course, member_name, member, name
         from
             `tabLMS Enrollment`
         where
@@ -27,7 +27,7 @@ def notify_course_completion():
     for item in enrollment_details:
         if item.course not in enrollments:
             enrollments[item.course] = {'course': item.course, 'members': [], 'names': []}
-        enrollments[item.course]['members'].append(item.member_name)
+        enrollments[item.course]['members'].append(item.member)
         enrollments[item.course]['names'].append(item.name)
     enrollments = list(enrollments.values())
 
@@ -101,7 +101,7 @@ def notify_assignment_submission():
     # Get all Assignment Submission that not send the notification to instructor
     query = '''
         select
-            course, lesson, member_name, name, assignment_title, assignment
+            course, lesson, member_name, member, name, assignment_title, assignment
         from
             `tabLMS Assignment Submission`
         where
@@ -115,7 +115,7 @@ def notify_assignment_submission():
     for item in submission_details:
         if item.course not in submissions:
             submissions[item.course] = {'course': item.course,  'assignment_title': item.assignment_title, 'members': [], 'names': []}
-        member_details = {'member': item.member_name, 'assignment_submission': item.name, 'assignment_title': item.assignment_title}
+        member_details = {'member': item.member_name, 'member_id': item.member, 'assignment_submission': item.name, 'assignment_title': item.assignment_title}
         submissions[item.course]['members'].append(member_details)
         submissions[item.course]['names'].append(item.name)
     submissions = list(submissions.values())
@@ -189,7 +189,7 @@ def notify_quiz_submission():
     # Get all Quiz Submission that not send the notification to instructor
     query = '''
         select
-            quiz, course, member_name, name
+            quiz, course, member_name, member, name, score, IF(percentage >= passing_percentage, "PASS", "FAIL") as result
         from
             `tabLMS Quiz Submission`
         where
@@ -203,7 +203,7 @@ def notify_quiz_submission():
     for item in submission_details:
         if item.course not in submissions:
             submissions[item.course] = {'course': item.course,  'quiz': frappe.db.get_value('LMS Quiz', item.quiz, 'title'), 'members': [], 'names': []}
-        member_details = {'member': item.member_name, 'quiz_submission': item.name}
+        member_details = {'member': item.member_name, 'member_id': item.member, 'quiz_submission': item.name, 'score': item.score, 'result': item.result}
         submissions[item.course]['members'].append(member_details)
         submissions[item.course]['names'].append(item.name)
     submissions = list(submissions.values())

--- a/lms/patches/v2_0/create_email_templates.py
+++ b/lms/patches/v2_0/create_email_templates.py
@@ -1,0 +1,174 @@
+import frappe
+
+
+def execute():
+    create_assignment_completion_eod_template()
+    create_quiz_submission_eod_template()
+    create_course_completion_eod_template()
+    set_default_eod_templates()
+    frappe.db.commit()
+
+def create_assignment_completion_eod_template():
+    doc = frappe.new_doc("Email Template")
+    doc.name = "Daily Assignment Completion"
+    doc.use_html = 1
+    doc.subject = "Daily Assignment Submission Information"
+    template = """
+    <!--
+        Available data format -> 
+        {
+            'assignment_title': 'Assignment Title', 
+            'members': [{
+                'member': 'John Doe', 
+                'assignment_submission': 'ASG-SUB-XXXXX', 
+                'assignment_title': 'Assignment Title'
+            }]
+        }
+    -->
+    <p>
+        {{ _("The following trainees have submitted their assignments.") }}
+    </p>
+    <br>
+    <table class="table table-bordered table-condensed">
+        <thead>
+        <tr>
+        <th class="text-center">SI No.</th>
+        <th class="text-center">ID Number</th>
+        <th class="text-center">Trainee Name</th>
+        <th class="text-center">Course Name</th>
+        <th class="text-center">Assignment Topic</th>
+        <th class="text-center">Submission Date</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for member in members %}
+            {% set user = frappe.db.get_value("User", member.member_id, ["username"], as_dict=True) %}
+            {% set course = frappe.db.get_value("LMS Course", member["course"], ["title", "name", "image"], as_dict=True) %}    
+            {% set submission_date = frappe.db.get_value("LMS Assignment Submission", member["assignment_submission"], ["creation"], as_dict=True) %}    
+            <tr>
+            <td class="text-center">{{ loop.index }}</th>
+            <td class="text-center">{{ user.username }}</th>
+            <td class="text-center">{{ member['member'] }}</td>
+            <td class="text-center">{{ course.title }}</td>
+            <td class="text-center"><a href="app/lms-assignment-submission/{{ member['assignment_submission'] }}">{{ assignment_title }}</a></td>
+            <td class="text-center">{{ frappe.format(submission_date['creation'], {'fieldtype': 'Date'}) }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+    </table>
+    """
+    doc.response_html = template
+    doc.insert()
+
+
+def create_quiz_submission_eod_template():
+    doc = frappe.new_doc("Email Template")
+    doc.name = "Daily Quiz Submission"
+    doc.use_html = 1
+    doc.subject = "Daily Quiz Submission Information"
+    template = """
+        <!--
+            Available data format -> 
+            {
+                'course': 'avsec-awareness-awareness-course', 
+                'quiz' 'Security Awareness Course Evaluation',
+                'members': [{'member': 'John Doe', 'member_id': 'johndoe@gmail.com', 'quiz_submission': '4645asa23', 'score': 87, 'result': 'PASS'}], 
+                'names': ['4645asa23']  (IDs of LMS Quiz submission)
+            }
+        -->
+        {% set date = frappe.format_date(frappe.utils.today()) %}
+        {% set course = frappe.db.get_value("LMS Course", course, ["title", "name", "image"], as_dict=True) %}    
+        <p>
+            {{ _("The following trainees have submitted their quiz.") }}
+        </p>
+        <br>
+        <table class="table table-bordered table-condensed">
+            <thead>
+            <tr>
+            <th class="text-center">SI No.</th>
+            <th class="text-center">ID Number</th>
+            <th class="text-center">Trainee Name</th>
+            <th class="text-center">Course Name</th>
+            <th class="text-center">Quiz Submission</th>
+            <th class="text-center">Evaluation Score</th>
+            <th class="text-center">Result</th>
+            <th class="text-center">Date of Submission</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for member in members %}
+                {% set quiz = frappe.db.get_value("LMS Quiz Submission", member.quiz_submission, ["creation", "quiz"], as_dict=True) %}
+                {% set user = frappe.db.get_value("User", member.member_id, ["username"], as_dict=True) %}
+                <tr>
+                <td class="text-center">{{ loop.index }}</th>
+                <td class="text-center">{{ user.username }}</th>
+                <td class="text-center">{{ member.member }}</td>
+                <td class="text-center">{{ course.title }}</td>
+                <td class="text-center">
+                    <a href="app/lms-quiz-submission/{{ member['quiz_submission'] }}">
+                    {{ frappe.db.get_value("LMS Quiz", quiz.quiz, "title")}}
+                    </a>
+                </td>
+                <td class="text-center">{{ member.score }}</td>
+                <td class="text-center">{{ member.result }}</td>
+                <td class="text-center">{{ frappe.format(quiz['creation'], {'fieldtype': 'Date'}) }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+        </table>
+    """
+    doc.response_html = template
+    doc.insert()
+
+
+def create_course_completion_eod_template():
+    doc = frappe.new_doc("Email Template")
+    doc.name = "Course Completion"
+    doc.use_html = 1
+    doc.subject = "Course Completion Notification"
+    template = """
+        <!--
+            Available data format -> 
+            {
+                'course': 'avsec-awareness-awareness-course', 
+                'members': ['John Doe', 'Jane Doe'], 
+                'names': ['6d20f46457', '99b4102534']  (IDs of LMS Enrollment)
+            }
+        -->
+        {% set date = frappe.format_date(frappe.utils.today()) %}
+        {% set course = frappe.db.get_value("LMS Course", course, ["title", "name", "image"], as_dict=True) %}    
+        <p>
+            {{ _("The following trainees have successfully completed the course {0} on {1}").format(frappe.bold(course_name), date) }}
+        </p>
+        <br>
+        <table class="table table-bordered table-condensed">
+            <thead>
+            <tr>
+            <th class="text-center">SI No.</th>
+            <th class="text-center">ID Number</th>
+            <th class="text-center">Trainee Name</th>
+            <th class="text-center">Course Name</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for member in members %}
+            {% set user = frappe.db.get_value("User", member, ["full_name", "username"], as_dict=True) %}    
+                <tr>
+                <td class="text-center">{{ loop.index }}</th>
+                <td class="text-center">{{ user.username }}</th>
+                <td class="text-center">{{ user.full_name }}</td>
+                <td class="text-center">{{ course.title }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+        </table>
+    """
+    doc.response_html = template
+    doc.insert()
+
+
+def set_default_eod_templates():
+    frappe.db.set_value("LMS Settings", None, "assignment_submission_template", "Daily Assignment Completion")
+    frappe.db.set_value("LMS Settings", None, "course_completion_notification_template", "Course Completion")
+    frappe.db.set_value("LMS Settings", None, "quiz_submission_template", "Daily Quiz Submission")
+    

--- a/lms/templates/emails/lms_assignment_submission_group_template.html
+++ b/lms/templates/emails/lms_assignment_submission_group_template.html
@@ -1,10 +1,42 @@
+<!--
+    Available data format -> 
+    {
+        'assignment_title': 'Assignment Title', 
+        'members': [{
+            'member': 'John Doe', 
+            'assignment_submission': 'ASG-SUB-XXXXX', 
+            'assignment_title': 'Assignment Title'
+        }]
+    }
+-->
 <p>
-    {{ _("The under-listed learners have submitted the assignment {0}").format(frappe.bold(assignment_title)) }}
+    {{ _("The following trainees have submitted their assignments.") }}
 </p>
 <br>
-<p> {{ _("Members (Assignment Link):") }} </p>
-<ul>
-{% for member in members %}
-<li> {{ member['member'] }} (<a href="app/lms-assignment-submission/{{ member['assignment_submission'] }}">{{ assignment_title }}</a>)</li>
-{% endfor %}
-</ul>
+<table class="table table-bordered table-condensed">
+    <thead>
+    <tr>
+      <th class="text-center">SI No.</th>
+      <th class="text-center">ID Number</th>
+      <th class="text-center">Trainee Name</th>
+      <th class="text-center">Course Name</th>
+      <th class="text-center">Assignment Topic</th>
+      <th class="text-center">Submission Date</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for member in members %}
+        {% set user = frappe.db.get_value("User", member.member_id, ["username"], as_dict=True) %}
+        {% set course = frappe.db.get_value("LMS Course", member["course"], ["title", "name", "image"], as_dict=True) %}    
+        {% set submission_date = frappe.db.get_value("LMS Assignment Submission", member["assignment_submission"], ["creation"], as_dict=True) %}    
+        <tr>
+          <td class="text-center">{{ loop.index }}</th>
+          <td class="text-center">{{ user.username }}</th>
+          <td class="text-center">{{ member['member'] }}</td>
+          <td class="text-center">{{ course.title }}</td>
+          <td class="text-center"><a href="app/lms-assignment-submission/{{ member['assignment_submission'] }}">{{ assignment_title }}</a></td>
+          <td class="text-center">{{ frappe.format(submission_date['creation'], {'fieldtype': 'Date'}) }}</td>
+        </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/lms/templates/emails/lms_course_completion.html
+++ b/lms/templates/emails/lms_course_completion.html
@@ -1,13 +1,35 @@
+<!--
+    Available data format -> 
+    {
+        'course': 'avsec-awareness-awareness-course', 
+        'members': ['John Doe', 'Jane Doe'], 
+        'names': ['6d20f46457', '99b4102534']  (IDs of LMS Enrollment)
+    }
+-->
+{% set date = frappe.format_date(frappe.utils.today()) %}
+{% set course = frappe.db.get_value("LMS Course", course, ["title", "name", "image"], as_dict=True) %}    
 <p>
-    {{ _("The under-listed learners have completed the course {0}").format(frappe.bold(course_name)) }}
+    {{ _("The following trainees have successfully completed the course {0} on {1}").format(frappe.bold(course_name), date) }}
 </p>
 <br>
-<p> {{ _("Members are:") }} </p>
-<ul>
-{% for member in members %}
-<li> {{ member }} </li>
-{% endfor %}
-</ul>
-<a href="/lms-course/{{ course }}">
-    {{ _("Open Course") }}
-</a>
+<table class="table table-bordered table-condensed">
+    <thead>
+    <tr>
+      <th class="text-center">SI No.</th>
+      <th class="text-center">ID Number</th>
+      <th class="text-center">Trainee Name</th>
+      <th class="text-center">Course Name</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for member in members %}
+    {% set user = frappe.db.get_value("User", member, ["full_name", "username"], as_dict=True) %}    
+        <tr>
+          <td class="text-center">{{ loop.index }}</th>
+          <td class="text-center">{{ user.username }}</th>
+          <td class="text-center">{{ user.full_name }}</td>
+          <td class="text-center">{{ course.title }}</td>
+        </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/lms/templates/emails/lms_quiz_submission_group_template.html
+++ b/lms/templates/emails/lms_quiz_submission_group_template.html
@@ -1,10 +1,49 @@
+<!--
+    Available data format -> 
+    {
+        'course': 'avsec-awareness-awareness-course', 
+        'quiz' 'Security Awareness Course Evaluation',
+        'members': [{'member': 'John Doe', 'member_id': 'johndoe@gmail.com', 'quiz_submission': '4645asa23', 'score': 87, 'result': 'PASS'}], 
+        'names': ['4645asa23']  (IDs of LMS Quiz submission)
+    }
+-->
+{% set date = frappe.format_date(frappe.utils.today()) %}
+{% set course = frappe.db.get_value("LMS Course", course, ["title", "name", "image"], as_dict=True) %}    
 <p>
-    {{ _("The under-listed learners have submitted the quiz {0}").format(frappe.bold(quiz)) }}
+    {{ _("The following trainees have submitted their quiz.") }}
 </p>
 <br>
-<p> {{ _("Members (Assignment Link):") }} </p>
-<ul>
-{% for member in members %}
-<li> {{ member['member'] }} (<a href="/app/lms-quiz-submission/{{ member['quiz_submission'] }}">{{ quiz }}</a>)</li>
-{% endfor %}
-</ul>
+<table class="table table-bordered table-condensed">
+    <thead>
+    <tr>
+      <th class="text-center">SI No.</th>
+      <th class="text-center">ID Number</th>
+      <th class="text-center">Trainee Name</th>
+      <th class="text-center">Course Name</th>
+      <th class="text-center">Quiz Submission</th>
+      <th class="text-center">Evaluation Score</th>
+      <th class="text-center">Result</th>
+      <th class="text-center">Date of Submission</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for member in members %}
+        {% set quiz = frappe.db.get_value("LMS Quiz Submission", member.quiz_submission, ["creation", "quiz"], as_dict=True) %}
+        {% set user = frappe.db.get_value("User", member.member_id, ["username"], as_dict=True) %}
+        <tr>
+          <td class="text-center">{{ loop.index }}</th>
+          <td class="text-center">{{ user.username }}</th>
+          <td class="text-center">{{ member.member }}</td>
+          <td class="text-center">{{ course.title }}</td>
+          <td class="text-center">
+            <a href="app/lms-quiz-submission/{{ member['quiz_submission'] }}">
+              {{ frappe.db.get_value("LMS Quiz", quiz.quiz, "title")}}
+            </a>
+          </td>
+          <td class="text-center">{{ member.score }}</td>
+          <td class="text-center">{{ member.result }}</td>
+          <td class="text-center">{{ frappe.format(quiz['creation'], {'fieldtype': 'Date'}) }}</td>
+        </tr>
+    {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
1. Updated default email templates.
2. Patch to create Email templates as records in Email Template doctype and set those templates as default in LMS Settings doctype. 