### PR TITLE
feat: added font style option in text editor

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -14,7 +14,9 @@ app_license = "AGPL"
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/lms/css/lms.css"
-# app_include_js = "/assets/lms/js/lms.js"
+app_include_js = [
+	"text_editor.bundle.js"
+]
 
 # include js, css files in header of web template
 web_include_css = "lms.bundle.css"

--- a/lms/public/js/frappe/form/control/text_editor.js
+++ b/lms/public/js/frappe/form/control/text_editor.js
@@ -1,0 +1,23 @@
+import Quill from "quill";
+
+const font_families = ['serif', 'sansserif', 'monospace'];
+
+frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.form.ControlTextEditor {
+	make_quill_editor() {
+		// Attribute customizations must be defined before initialization of Quill editor
+		const Font = Quill.import("attributors/style/font");
+		Font.whitelist = font_families;
+		Quill.register(Font, true);
+
+		super.make_quill_editor();
+	}
+
+	get_toolbar_options() {
+		const options = super.get_toolbar_options();
+
+		// Inserting font family option in toolbar options array
+		options.splice(1, 0, [{ font: font_families }]);
+
+		return options;
+	}
+};

--- a/lms/public/js/text_editor.bundle.js
+++ b/lms/public/js/text_editor.bundle.js
@@ -1,0 +1,1 @@
+import "./frappe/form/control/text_editor.js";


### PR DESCRIPTION
### Requirement
When creating a lesson, there's no option to select the font style.
It would be great if we could add the ability to choose fonts within the lesson creation process. This would allow for more customization and improve the overall look and feel of our lessons.

### Changes
1. Added text editor override to for customization
2. Modified text editor default toolbar options to add font options
3. Registered default fonts in text editor