### PR TITLE
feat: optimized course details page and update lesson completion scenario

### DIFF
--- a/lms/hooks.py
+++ b/lms/hooks.py
@@ -240,6 +240,7 @@ jinja = {
 		"lms.lms.utils.get_chapters",
 		"lms.lms.utils.get_slugified_chapter_title",
 		"lms.lms.utils.get_progress",
+		"lms.lms.utils.get_course_lessons_progress",
 		"lms.lms.utils.render_html",
 		"lms.lms.utils.is_mentor",
 		"lms.lms.utils.is_cohort_staff",

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -305,6 +305,26 @@ def get_progress(course, lesson, member=None):
 		["status"],
 	)
 
+def get_course_lessons_progress(course):
+	"""
+    Fetch the progress of all lessons in the given course for a logged in user.
+    
+    Args:
+        course (str): Name of the course.
+        
+    Returns:
+        dict: A dictionary mapping lesson names to their progress status ('Complete' or other).
+    """
+    # Fetch all lessons for the course
+	lessons = frappe.get_all("Course Lesson", filters={"course": course}, fields=["name"])
+
+	progress_data = {}
+	
+	for lesson in lessons:
+		progress_data[lesson['name']] = get_progress(course, lesson['name'])
+			
+	return progress_data
+
 
 def render_html(lesson):
 	youtube = lesson.youtube

--- a/lms/lms/widgets/CourseOutline.html
+++ b/lms/lms/widgets/CourseOutline.html
@@ -1,5 +1,10 @@
 {% set chapters = get_chapters(course.name) %}
 {% set is_instructor = is_instructor(course.name) %}
+{% set lessons_progress = {} %}
+
+{% if membership %}
+    {% set lessons_progress = get_course_lessons_progress(course.name) %}
+{% endif %}
 
 {% if chapters | length %}
 <div class="course-home-outline">
@@ -68,8 +73,8 @@
 
                     <span>{{ lesson.title }}</span>
 
-                    {% if membership %}
-                    <svg class="icon icon-md lesson-progress-tick ml-auto {{ get_progress(course.name, lesson.name) != 'Complete' and 'hide' }}">
+                    {% if membership and lessons_progress %}
+                    <svg class="icon icon-md lesson-progress-tick ml-auto {{ lessons_progress[lesson.name] != 'Complete' and 'hide' }}">
                         <use class="" href="#icon-success">
                     </svg>
                     {% endif %}

--- a/lms/www/batch/learn.js
+++ b/lms/www/batch/learn.js
@@ -1,24 +1,11 @@
 frappe.ready(() => {
-	this.marked_as_complete = false;
-	let self = this;
-
 	frappe.telemetry.capture("on_lesson_page", "lms");
 
 	fetch_assignments();
 
 	save_current_lesson();
 
-	$(window).scroll(() => {
-		let self = this;
-		if (
-			!$("#status-indicator").length &&
-			!self.marked_as_complete &&
-			$(".title").hasClass("is-member")
-		) {
-			self.marked_as_complete = true;
-			mark_progress();
-		}
-	});
+	activate_reading_timer();
 
 	$("#certification").click((e) => {
 		create_certificate(e);
@@ -49,6 +36,36 @@ const save_current_lesson = () => {
 			lesson_name: $(".title").attr("data-lesson"),
 		});
 	}
+};
+
+const activate_reading_timer = () => {
+	// If 'Completed' indicator exists or user not member of the course then return
+	if (
+		$("#status-indicator").length ||
+		!$(".title").hasClass("is-member")
+	) {
+		return
+	}
+
+	const nextLessonButton = $(".btn.next")
+	const initialContent = nextLessonButton.text();
+	
+    let timeLeft = 10;
+
+	nextLessonButton.addClass("disabled");
+
+    const timerInterval = setInterval(() => {
+        if (timeLeft > 0) {
+            nextLessonButton.text(`Please wait for ${timeLeft} seconds`);
+            timeLeft--;
+        } else {
+            clearInterval(timerInterval);
+
+			mark_progress()
+            nextLessonButton.text(initialContent);
+            nextLessonButton.removeClass("disabled");
+        }
+    }, 1000);
 };
 
 const mark_progress = () => {


### PR DESCRIPTION
### Requirement
- Course lesson completion logic should not be based on scroll activity of user
- Optimize course detail page

### Changes
- Course lessons progress fetched at once instead of fetching through jinja templating loop
- Updated course lesson completion logic and added a timer to force user stay at lesson page for certain time